### PR TITLE
Polishes out useless log messages

### DIFF
--- a/kafka-zookeeper/Dockerfile
+++ b/kafka-zookeeper/Dockerfile
@@ -14,16 +14,16 @@ RUN /tmp/install && rm /tmp/install
 
 # Share the same base image to reduce layers used in testing
 FROM hypertrace/java:11
-MAINTAINER Hypertrace "https://www.hypertrace.org/"
+LABEL maintainer="Hypertrace https://www.hypertrace.org/"
 
 # Add HEALTHCHECK and ENTRYPOINT scripts into the default search path
 COPY docker-bin/* /usr/local/bin/
 
-# All Kafka content including binaries and logs write under WORKDIR
+# All content including binaries and logs write under WORKDIR
 WORKDIR /opt/kafka
+ARG USER=kafka
 
 # Ensure the process doesn't run as root
-ARG USER=kafka
 RUN adduser -g '' -h ${PWD} -D ${USER}
 USER ${USER}
 
@@ -34,7 +34,7 @@ COPY --from=install --chown=${USER} /install .
 ENV KAFKA_ADVERTISED_HOST_NAME=localhost
 EXPOSE 2181 9092 19092
 
-# We use start period of 30s to avoid marking Kafka unhealthy on slow or contended CI hosts
+# We use start period of 30s to avoid marking the container unhealthy on slow or contended CI hosts
 HEALTHCHECK --interval=1s --start-period=30s --timeout=5s CMD ["docker-healthcheck"]
 
 ENTRYPOINT ["start-kafka-zookeeper"]

--- a/kafka-zookeeper/docker-bin/start-kafka-zookeeper
+++ b/kafka-zookeeper/docker-bin/start-kafka-zookeeper
@@ -13,16 +13,14 @@ KAFKA_CONFIG=./config/server.properties
 grep -qF -- "$ADVERTISED_LISTENERS" $KAFKA_CONFIG || echo "$ADVERTISED_LISTENERS" >> $KAFKA_CONFIG
 
 echo Starting ZooKeeper
-
 bin/kafka-run-class.sh \
   -Dlog4j.configuration=file:./config/log4j.properties \
   org.apache.zookeeper.server.quorum.QuorumPeerMain ./config/zookeeper.properties &
 
 # Wait for ZooKeeper to be ok
-until echo ruok | nc 127.0.0.1 2181
-do
-  sleep 1
-done
+until echo ruok | nc 127.0.0.1 2181 > /dev/null; do sleep 1; done
 
 echo Starting Kafka
-exec bin/kafka-run-class.sh -name kafkaServer -Dlog4j.configuration=file:./config/log4j.properties kafka.Kafka ./config/server.properties
+exec bin/kafka-run-class.sh -name kafkaServer \
+  -Dlog4j.configuration=file:./config/log4j.properties \
+  kafka.Kafka ./config/server.properties

--- a/kafka-zookeeper/install
+++ b/kafka-zookeeper/install
@@ -13,9 +13,13 @@ wget -qO- $APACHE_MIRROR/kafka/$KAFKA_VERSION/kafka_$SCALA_VERSION-$KAFKA_VERSIO
 
 # Remove bash as our images don't have it, and it isn't required
 sed -i 's~#!/bin/bash~#!/bin/sh~g' bin/*sh
+# Remove bash syntax relating to irrelevant CYGWIN (prevents console errors)
+sed -i -e 's/$(uname -a) =~ "CYGWIN"/0/g' -e  's/.*\(\( CYGWIN \)\).*//g' bin/*
+# Remove bash shopt commands (kafka-start-class uses nullglob, but it is non-critical to avoid it)
+sed -i 's/.*shopt.*//g' bin/*sh
 
-# don't log ZK connections
-sed -i 's~log4j.logger.org.apache.zookeeper=INFO~log4j.logger.org.apache.zookeeper=WARN~g' config/log4j.properties
+# Hush logging for both Kafka and ZooKeeper
+sed -i 's~INFO~WARN~g' config/log4j.properties
 
 # Make sure you use relative paths in references like this, so that installation
 # is decoupled from runtime


### PR DESCRIPTION

down to this now

```
kafka-zookeeper                 | Starting ZooKeeper
kafka-zookeeper                 | [2020-08-30 06:40:46,853] WARN Either no config or no quorum defined in config, running  in standalone mode (org.apache.zookeeper.server.quorum.QuorumPeerMain)
kafka-zookeeper                 | Starting Kafka
kafka-zookeeper                 | [2020-08-30 06:40:48,749] WARN No meta.properties file under dir /opt/kafka/./data/kafka/meta.properties (kafka.server.BrokerMetadataCheckpoint)
```