### PR TITLE
Uses file extension to clarify the install script isn't a directory

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-  id("org.hypertrace.docker-plugin") version "0.6.1"
-  id("org.hypertrace.docker-publish-plugin") version "0.6.1"
+  id("org.hypertrace.docker-plugin") version "0.7.1"
+  id("org.hypertrace.docker-publish-plugin") version "0.7.1"
 }
 
 hypertraceDocker {

--- a/kafka-zookeeper/Dockerfile
+++ b/kafka-zookeeper/Dockerfile
@@ -9,12 +9,12 @@ ENV KAFKA_VERSION=2.6.0 SCALA_VERSION=2.13
 
 USER root
 WORKDIR /install
-ADD install /tmp/install
-RUN /tmp/install && rm /tmp/install
+COPY install.sh /tmp/
+RUN /tmp/install.sh && rm /tmp/install.sh
 
 # Share the same base image to reduce layers used in testing
 FROM hypertrace/java:11
-LABEL maintainer="Hypertrace https://www.hypertrace.org/"
+LABEL MAINTAINER Hypertrace "https://www.hypertrace.org/"
 
 # Add HEALTHCHECK and ENTRYPOINT scripts into the default search path
 COPY docker-bin/* /usr/local/bin/

--- a/kafka-zookeeper/install.sh
+++ b/kafka-zookeeper/install.sh
@@ -26,7 +26,7 @@ sed -i 's~INFO~WARN~g' config/log4j.properties
 mkdir -p data/kafka data/zookeeper logs
 
 # Set explicit, basic configuration
-cat > config/zookeeper.properties <<-EOF
+cat > config/zookeeper.properties <<-'EOF'
 dataDir=./data/zookeeper
 clientPort=2181
 maxClientCnxns=0
@@ -35,7 +35,7 @@ admin.enableServer=false
 4lw.commands.whitelist=srvr,ruok
 EOF
 
-cat > config/server.properties <<-EOF
+cat > config/server.properties <<-'EOF'
 broker.id=0
 zookeeper.connect=127.0.0.1:2181
 replica.socket.timeout.ms=1500


### PR DESCRIPTION
It is normal in UNIX to not add a shell script suffix even if it is
common in projects that have both windows and UNIX commands in them.

For example, the canonical name for the Docker HEALTHCHECK command is
`docker-healthcheck`, not `docker-healthcheck.sh`.

There's a special case @jcchavezs noticed when looking at how the
installation layer is setup. The word `install` is both used for a
root directory `/install` and also a script that populates that,
`/tmp/install`. This distracted him from other work and that's an
anti-goal.

Instead of deciding a different name for `/install` or a different
name for the `/tmp/install` script, this appends an otherwise
unnecessary `.sh` to the install script to avoid the problem without
creating a new naming problem.