### PR TITLE
allows tagOverride for helm charts

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -75,3 +75,11 @@ else use user-provided URL
 {{- printf "zookeeper.%s.svc.cluster.local:2181" .Release.Namespace }}
 {{- end -}}
 {{- end -}}
+
+{{- define "kafkaservice.image" -}}
+  {{- if and .Values.image.tagOverride  -}}
+    {{- printf "%s:%s" .Values.image.repository .Values.image.tagOverride }}
+  {{- else -}}
+    {{- printf "%s:%s" .Values.image.repository .Chart.Version }}
+  {{- end -}}
+{{- end -}}

--- a/helm/templates/statefulset.yaml
+++ b/helm/templates/statefulset.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: {{ template "kafka.serviceAccountName" . }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Chart.Version }}"
+          image: "{{ include "kafkaservice.image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             {{- range $key, $value := .Values.listeners }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -9,6 +9,7 @@ replicaCount: 1
 image:
   repository: "hypertrace/kafka"
   pullPolicy: "IfNotPresent"
+  tagOverride: ""
 
 imagePullSecrets: []
 


### PR DESCRIPTION
## Description
addresses https://github.com/hypertrace/hypertrace/issues/55
based on: https://github.com/hypertrace/pinot/pull/18

### Testing
Tested with personal EKS cluster deployment by adding following lines in values.yaml for hypertrace deployment.

Works as expected. 

### Checklist:
- [x] My changes generate no new warnings
- [na] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
