### PR TITLE
upgrade kafka to version 3.3.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # TODO: port this similarly to kafka-zookeeper in order to share base layer
 # The only assumption we make about this FROM is that it has a JRE in path
-FROM adoptopenjdk/openjdk11:jre-11.0.16.1_1@sha256:1e458a6a926a6265eb8abf1a4074162ee35984652b01d772f206b57406de0656
+FROM adoptopenjdk/openjdk11:jre-11.0.18_10@sha256:fefef769fd9f1c2cb22e08b70f2adf13d79fc98f858d93e7f04a47f0afd99a4d
 
 # Use latest stable release here. Scala 2.13+ supports JRE 14
-ENV KAFKA_VERSION=3.2.1 SCALA_VERSION=2.13
+ENV KAFKA_VERSION=3.3.2 SCALA_VERSION=2.13
 
 RUN set -ex; \
   export DEBIAN_FRONTEND=noninteractive; \
@@ -24,10 +24,6 @@ RUN set -ex; \
   rm kafka_$SCALA_BINARY_VERSION-$KAFKA_VERSION.tgz; \
   \
   rm -rf /opt/kafka/site-docs; \
-  \
-  mkdir -p /opt/kafka/prometheus; \
-  curl -s -o /opt/kafka/prometheus/jmx_prometheus_javaagent-0.12.0.jar https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.12.0/jmx_prometheus_javaagent-0.12.0.jar; \
-  curl -s -o /opt/kafka/prometheus/kafka-2_0_0.yml https://raw.githubusercontent.com/prometheus/jmx_exporter/master/example_configs/kafka-2_0_0.yml; \
   \
   apt-get purge -y --auto-remove $buildDeps; \
   rm -rf /var/lib/apt/lists/*; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # TODO: port this similarly to kafka-zookeeper in order to share base layer
 # The only assumption we make about this FROM is that it has a JRE in path
-FROM adoptopenjdk/openjdk11:jre-11.0.18_10@sha256:fefef769fd9f1c2cb22e08b70f2adf13d79fc98f858d93e7f04a47f0afd99a4d
+FROM adoptopenjdk/openjdk11:jre-11.0.18_10@sha256:3282670f5b315c731cb69d62b5d7eb195392be4a55d22a398c9ed1008490de7d
 
 # Use latest stable release here. Scala 2.13+ supports JRE 14
 ENV KAFKA_VERSION=3.3.2 SCALA_VERSION=2.13

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: kafka
 type: application
 description: kafka helm chart
-appVersion: 2.3.0
+appVersion: 3.3.2
 version: 0.1.0

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -182,7 +182,7 @@ prometheus:
     enabled: false
     image:
       repository: hypertrace/prometheus-jmx-exporter
-      tag: 0.1.1
+      tag: 0.1.2
       pullPolicy: IfNotPresent
     port: 5558
     resources:

--- a/kafka-zookeeper/Dockerfile
+++ b/kafka-zookeeper/Dockerfile
@@ -5,7 +5,7 @@
 FROM cimg/openjdk:14.0.2 AS install
 
 # Use latest stable release here. Scala 2.13+ supports JRE 14
-ENV KAFKA_VERSION=3.2.1 SCALA_VERSION=2.13
+ENV KAFKA_VERSION=3.3.2 SCALA_VERSION=2.13
 
 USER root
 WORKDIR /install


### PR DESCRIPTION
Fixes the following Vulnerabilities:
1. CVE-2017-18640
2. CVE-2020-16156
3. CVE-2021-43618
4. CVE-2022-1586
5. CVE-2022-1587
6. CVE-2022-2047
7. CVE-2022-24823
8. CVE-2022-25857
9. CVE-2022-28321
10. CVE-2022-37434
11. CVE-2022-38749
12. CVE-2022-38750
13. CVE-2022-38751
14. CVE-2022-38752
15. CVE-2022-40674
16. CVE-2022-41854
17. CVE-2022-42003
18. CVE-2022-42004
19. CVE-2022-43680