### PR TITLE
upgrade kafka to version 3.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,13 @@
-# TODO: port this similarly to kafka-zookeeper in order to share base layer
-# The only assumption we make about this FROM is that it has a JRE in path
-FROM adoptopenjdk/openjdk11:jre-11.0.19_7@sha256:a2160bc43c40d98324f43260344bf70f3a1d6a408d5dc005d2e6fb4f0f788ec4
+FROM adoptopenjdk/openjdk11:jre-11.0.21_9@sha256:adbfa4e7aee9bd8d39424b018cb9835261929622d0b169b26b10c2e04fa6b8ff
 
 # Use latest stable release here. Scala 2.13+ supports JRE 14
-ENV KAFKA_VERSION=3.3.2 SCALA_VERSION=2.13
+ENV KAFKA_VERSION=3.6.0 SCALA_VERSION=2.13
 
 RUN set -ex; \
   export DEBIAN_FRONTEND=noninteractive; \
   runDeps='netcat-openbsd'; \
   buildDeps='curl ca-certificates gnupg dirmngr'; \
-  apt-get update && apt-get install -y $runDeps $buildDeps --no-install-recommends; \
+  apt-get update && apt-get upgrade -y && apt-get install -y $runDeps $buildDeps --no-install-recommends; \
   \
   curl -s -L -o KEYS https://www.apache.org/dist/kafka/KEYS; \
   gpg --import KEYS && rm KEYS; \
@@ -21,6 +19,9 @@ RUN set -ex; \
   curl -SLs -o kafka_$SCALA_BINARY_VERSION-$KAFKA_VERSION.tgz "https://archive.apache.org/dist/kafka/$KAFKA_VERSION/kafka_$SCALA_BINARY_VERSION-$KAFKA_VERSION.tgz"; \
   gpg --verify kafka_$SCALA_BINARY_VERSION-$KAFKA_VERSION.tgz.asc kafka_$SCALA_BINARY_VERSION-$KAFKA_VERSION.tgz; \
   tar xzf kafka_$SCALA_BINARY_VERSION-$KAFKA_VERSION.tgz --strip-components=1 -C /opt/kafka; \
+  rm /opt/kafka/libs/zookeeper-3.8.2.jar /opt/kafka/libs/zookeeper-jute-3.8.2.jar; \
+  curl -SLs -o /opt/kafka/libs/zookeeper-3.8.2.jar https://repo1.maven.org/maven2/org/apache/zookeeper/zookeeper/3.8.3/zookeeper-3.8.3.jar; \
+  curl -SLs -o /opt/kafka/libs/zookeeper-jute-3.8.2.jar https://repo1.maven.org/maven2/org/apache/zookeeper/zookeeper-jute/3.8.3/zookeeper-jute-3.8.3.jar; \
   rm kafka_$SCALA_BINARY_VERSION-$KAFKA_VERSION.tgz; \
   \
   rm -rf /opt/kafka/site-docs; \

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: kafka
 type: application
 description: kafka helm chart
-appVersion: 3.3.2
+appVersion: 3.6.0
 version: 0.1.0

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -182,7 +182,7 @@ prometheus:
     enabled: false
     image:
       repository: hypertrace/prometheus-jmx-exporter
-      tag: 0.1.3
+      tag: 0.1.4
       pullPolicy: IfNotPresent
     port: 5558
     resources:

--- a/kafka-zookeeper/Dockerfile
+++ b/kafka-zookeeper/Dockerfile
@@ -5,7 +5,7 @@
 FROM cimg/openjdk:14.0.2 AS install
 
 # Use latest stable release here. Scala 2.13+ supports JRE 14
-ENV KAFKA_VERSION=3.3.2 SCALA_VERSION=2.13
+ENV KAFKA_VERSION=3.6.0 SCALA_VERSION=2.13
 
 USER root
 WORKDIR /install

--- a/kafka-zookeeper/install.sh
+++ b/kafka-zookeeper/install.sh
@@ -71,6 +71,16 @@ cat > pom.xml <<-'EOF'
       <artifactId>slf4j-log4j12</artifactId>
       <version>1.7.36</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.zookeeper</groupId>
+      <artifactId>zookeeper</artifactId>
+      <version>3.8.3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.zookeeper</groupId>
+      <artifactId>zookeeper-jute</artifactId>
+      <version>3.8.3</version>
+    </dependency>
   </dependencies>
 </project>
 EOF


### PR DESCRIPTION
fixes the following vulnerabilities:
```
hypertrace/kafka:0.2.3 (ubuntu 20.04)

Total: 26 (UNKNOWN: 0, LOW: 21, MEDIUM: 5, HIGH: 0, CRITICAL: 0)

┌─────────────┬────────────────┬──────────┬──────────┬──────────────────────────┬─────────────────────┬──────────────────────────────────────────────────────────────┐
│   Library   │ Vulnerability  │ Severity │  Status  │    Installed Version     │    Fixed Version    │                            Title                             │
├─────────────┼────────────────┼──────────┼──────────┼──────────────────────────┼─────────────────────┼──────────────────────────────────────────────────────────────┤
│ coreutils   │ CVE-2016-2781  │ LOW      │ affected │ 8.30-3ubuntu2            │                     │ coreutils: Non-privileged session can escape to the parent   │
│             │                │          │          │                          │                     │ session in chroot                                            │
│             │                │          │          │                          │                     │ https://avd.aquasec.com/nvd/cve-2016-2781                    │
├─────────────┼────────────────┤          │          ├──────────────────────────┼─────────────────────┼──────────────────────────────────────────────────────────────┤
│ gpgv        │ CVE-2022-3219  │          │          │ 2.2.19-3ubuntu2.2        │                     │ denial of service issue (resource consumption) using         │
│             │                │          │          │                          │                     │ compressed packets                                           │
│             │                │          │          │                          │                     │ https://avd.aquasec.com/nvd/cve-2022-3219                    │
├─────────────┼────────────────┼──────────┤          ├──────────────────────────┼─────────────────────┼──────────────────────────────────────────────────────────────┤
│ libc-bin    │ CVE-2023-5156  │ MEDIUM   │          │ 2.31-0ubuntu9.9          │                     │ glibc: DoS due to memory leak in getaddrinfo.c               │
│             │                │          │          │                          │                     │ https://avd.aquasec.com/nvd/cve-2023-5156                    │
│             ├────────────────┼──────────┤          │                          ├─────────────────────┼──────────────────────────────────────────────────────────────┤
│             │ CVE-2016-20013 │ LOW      │          │                          │                     │ sha256crypt and sha512crypt through 0.6 allow attackers to   │
│             │                │          │          │                          │                     │ cause a denial of...                                         │
│             │                │          │          │                          │                     │ https://avd.aquasec.com/nvd/cve-2016-20013                   │
│             ├────────────────┤          │          │                          ├─────────────────────┼──────────────────────────────────────────────────────────────┤
│             │ CVE-2023-4806  │          │          │                          │                     │ glibc: potential use-after-free in getaddrinfo()             │
│             │                │          │          │                          │                     │ https://avd.aquasec.com/nvd/cve-2023-4806                    │
│             ├────────────────┤          │          │                          ├─────────────────────┼──────────────────────────────────────────────────────────────┤
│             │ CVE-2023-4813  │          │          │                          │                     │ glibc: potential use-after-free in gaih_inet()               │
│             │                │          │          │                          │                     │ https://avd.aquasec.com/nvd/cve-2023-4813                    │
├─────────────┼────────────────┼──────────┤          │                          ├─────────────────────┼──────────────────────────────────────────────────────────────┤
│ libc6       │ CVE-2023-5156  │ MEDIUM   │          │                          │                     │ glibc: DoS due to memory leak in getaddrinfo.c               │
│             │                │          │          │                          │                     │ https://avd.aquasec.com/nvd/cve-2023-5156                    │
│             ├────────────────┼──────────┤          │                          ├─────────────────────┼──────────────────────────────────────────────────────────────┤
│             │ CVE-2016-20013 │ LOW      │          │                          │                     │ sha256crypt and sha512crypt through 0.6 allow attackers to   │
│             │                │          │          │                          │                     │ cause a denial of...                                         │
│             │                │          │          │                          │                     │ https://avd.aquasec.com/nvd/cve-2016-20013                   │
│             ├────────────────┤          │          │                          ├─────────────────────┼──────────────────────────────────────────────────────────────┤
│             │ CVE-2023-4806  │          │          │                          │                     │ glibc: potential use-after-free in getaddrinfo()             │
│             │                │          │          │                          │                     │ https://avd.aquasec.com/nvd/cve-2023-4806                    │
│             ├────────────────┤          │          │                          ├─────────────────────┼──────────────────────────────────────────────────────────────┤
│             │ CVE-2023-4813  │          │          │                          │                     │ glibc: potential use-after-free in gaih_inet()               │
│             │                │          │          │                          │                     │ https://avd.aquasec.com/nvd/cve-2023-4813                    │
├─────────────┼────────────────┼──────────┼──────────┼──────────────────────────┼─────────────────────┼──────────────────────────────────────────────────────────────┤
│ libgnutls30 │ CVE-2023-5981  │ MEDIUM   │ fixed    │ 3.6.13-2ubuntu1.8        │ 3.6.13-2ubuntu1.9   │ [ttiming side-channel inside RSA-PSK key exchange]           │
│             │                │          │          │                          │                     │ https://avd.aquasec.com/nvd/cve-2023-5981                    │
├─────────────┼────────────────┤          ├──────────┼──────────────────────────┼─────────────────────┼──────────────────────────────────────────────────────────────┤
│ liblzma5    │ CVE-2020-22916 │          │ affected │ 5.2.4-1ubuntu1.1         │                     │ Denial of service via decompression of crafted file          │
│             │                │          │          │                          │                     │ https://avd.aquasec.com/nvd/cve-2020-22916                   │
├─────────────┼────────────────┼──────────┤          ├──────────────────────────┼─────────────────────┼──────────────────────────────────────────────────────────────┤
│ libpcre3    │ CVE-2017-11164 │ LOW      │          │ 2:8.39-12ubuntu0.1       │                     │ OP_KETRMAX feature in the match function in pcre_exec.c      │
│             │                │          │          │                          │                     │ https://avd.aquasec.com/nvd/cve-2017-11164                   │
├─────────────┼────────────────┤          │          ├──────────────────────────┼─────────────────────┼──────────────────────────────────────────────────────────────┤
│ libpng16-16 │ CVE-2022-3857  │          │          │ 1.6.37-2                 │                     │ Null pointer dereference leads to segmentation fault         │
│             │                │          │          │                          │                     │ https://avd.aquasec.com/nvd/cve-2022-3857                    │
├─────────────┼────────────────┤          ├──────────┼──────────────────────────┼─────────────────────┼──────────────────────────────────────────────────────────────┤
│ libprocps8  │ CVE-2023-4016  │          │ fixed    │ 2:3.3.16-1ubuntu2.3      │ 2:3.3.16-1ubuntu2.4 │ procps: ps buffer overflow                                   │
│             │                │          │          │                          │                     │ https://avd.aquasec.com/nvd/cve-2023-4016                    │
├─────────────┼────────────────┤          ├──────────┼──────────────────────────┼─────────────────────┼──────────────────────────────────────────────────────────────┤
│ libsystemd0 │ CVE-2023-26604 │          │ affected │ 245.4-4ubuntu3.21        │                     │ systemd: privilege escalation via the less pager             │
│             │                │          │          │                          │                     │ https://avd.aquasec.com/nvd/cve-2023-26604                   │
├─────────────┤                │          │          │                          ├─────────────────────┤                                                              │
│ libudev1    │                │          │          │                          │                     │                                                              │
│             │                │          │          │                          │                     │                                                              │
├─────────────┼────────────────┼──────────┤          ├──────────────────────────┼─────────────────────┼──────────────────────────────────────────────────────────────┤
│ locales     │ CVE-2023-5156  │ MEDIUM   │          │ 2.31-0ubuntu9.9          │                     │ glibc: DoS due to memory leak in getaddrinfo.c               │
│             │                │          │          │                          │                     │ https://avd.aquasec.com/nvd/cve-2023-5156                    │
│             ├────────────────┼──────────┤          │                          ├─────────────────────┼──────────────────────────────────────────────────────────────┤
│             │ CVE-2016-20013 │ LOW      │          │                          │                     │ sha256crypt and sha512crypt through 0.6 allow attackers to   │
│             │                │          │          │                          │                     │ cause a denial of...                                         │
│             │                │          │          │                          │                     │ https://avd.aquasec.com/nvd/cve-2016-20013                   │
│             ├────────────────┤          │          │                          ├─────────────────────┼──────────────────────────────────────────────────────────────┤
│             │ CVE-2023-4806  │          │          │                          │                     │ glibc: potential use-after-free in getaddrinfo()             │
│             │                │          │          │                          │                     │ https://avd.aquasec.com/nvd/cve-2023-4806                    │
│             ├────────────────┤          │          │                          ├─────────────────────┼──────────────────────────────────────────────────────────────┤
│             │ CVE-2023-4813  │          │          │                          │                     │ glibc: potential use-after-free in gaih_inet()               │
│             │                │          │          │                          │                     │ https://avd.aquasec.com/nvd/cve-2023-4813                    │
├─────────────┼────────────────┤          │          ├──────────────────────────┼─────────────────────┼──────────────────────────────────────────────────────────────┤
│ login       │ CVE-2013-4235  │          │          │ 1:4.8.1-1ubuntu5.20.04.4 │                     │ shadow-utils: TOCTOU race conditions by copying and removing │
│             │                │          │          │                          │                     │ directory trees                                              │
│             │                │          │          │                          │                     │ https://avd.aquasec.com/nvd/cve-2013-4235                    │
│             ├────────────────┤          │          │                          ├─────────────────────┼──────────────────────────────────────────────────────────────┤
│             │ CVE-2023-29383 │          │          │                          │                     │ Improper input validation in shadow-utils package utility    │
│             │                │          │          │                          │                     │ chfn                                                         │
│             │                │          │          │                          │                     │ https://avd.aquasec.com/nvd/cve-2023-29383                   │
├─────────────┼────────────────┤          │          │                          ├─────────────────────┼──────────────────────────────────────────────────────────────┤
│ passwd      │ CVE-2013-4235  │          │          │                          │                     │ shadow-utils: TOCTOU race conditions by copying and removing │
│             │                │          │          │                          │                     │ directory trees                                              │
│             │                │          │          │                          │                     │ https://avd.aquasec.com/nvd/cve-2013-4235                    │
│             ├────────────────┤          │          │                          ├─────────────────────┼──────────────────────────────────────────────────────────────┤
│             │ CVE-2023-29383 │          │          │                          │                     │ Improper input validation in shadow-utils package utility    │
│             │                │          │          │                          │                     │ chfn                                                         │
│             │                │          │          │                          │                     │ https://avd.aquasec.com/nvd/cve-2023-29383                   │
├─────────────┼────────────────┤          ├──────────┼──────────────────────────┼─────────────────────┼──────────────────────────────────────────────────────────────┤
│ procps      │ CVE-2023-4016  │          │ fixed    │ 2:3.3.16-1ubuntu2.3      │ 2:3.3.16-1ubuntu2.4 │ procps: ps buffer overflow                                   │
│             │                │          │          │                          │                     │ https://avd.aquasec.com/nvd/cve-2023-4016                    │
└─────────────┴────────────────┴──────────┴──────────┴──────────────────────────┴─────────────────────┴──────────────────────────────────────────────────────────────┘
2023-11-27T12:08:13.325+0530	INFO	Table result includes only package filenames. Use '--format json' option to get the full path to the package file.

Java (jar)

Total: 13 (UNKNOWN: 0, LOW: 2, MEDIUM: 6, HIGH: 3, CRITICAL: 2)

┌─────────────────────────────────────────────────────────┬─────────────────────┬──────────┬────────┬───────────────────┬──────────────────────────────────────────────────┬──────────────────────────────────────────────────────────────┐
│                         Library                         │    Vulnerability    │ Severity │ Status │ Installed Version │                  Fixed Version                   │                            Title                             │
├─────────────────────────────────────────────────────────┼─────────────────────┼──────────┼────────┼───────────────────┼──────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ io.netty:netty-handler (netty-handler-4.1.78.Final.jar) │ CVE-2023-34462      │ MEDIUM   │ fixed  │ 4.1.78.Final      │ 4.1.94.Final                                     │ netty: SniHandler 16MB allocation leads to OOM               │
│                                                         │                     │          │        │                   │                                                  │ https://avd.aquasec.com/nvd/cve-2023-34462                   │
├─────────────────────────────────────────────────────────┼─────────────────────┼──────────┤        ├───────────────────┼──────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ org.apache.zookeeper:zookeeper (zookeeper-3.6.3.jar)    │ CVE-2023-44981      │ CRITICAL │        │ 3.6.3             │ 3.7.2, 3.8.3, 3.9.1                              │ zookeeper: Authorization Bypass in Apache ZooKeeper          │
│                                                         │                     │          │        │                   │                                                  │ https://avd.aquasec.com/nvd/cve-2023-44981                   │
├─────────────────────────────────────────────────────────┼─────────────────────┼──────────┤        ├───────────────────┼──────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ org.bitbucket.b_c:jose4j (jose4j-0.7.9.jar)             │ CVE-2023-31582      │ HIGH     │        │ 0.7.9             │ 0.9.3                                            │ jose4j: Insecure iteration count setting                     │
│                                                         │                     │          │        │                   │                                                  │ https://avd.aquasec.com/nvd/cve-2023-31582                   │
│                                                         ├─────────────────────┼──────────┤        │                   │                                                  ├──────────────────────────────────────────────────────────────┤
│                                                         │ GHSA-jgvc-jfgh-rjvv │ MEDIUM   │        │                   │                                                  │ Chosen Ciphertext Attack in Jose4j                           │
│                                                         │                     │          │        │                   │                                                  │ https://github.com/advisories/GHSA-jgvc-jfgh-rjvv            │
├─────────────────────────────────────────────────────────┼─────────────────────┤          │        ├───────────────────┼──────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ org.eclipse.jetty:jetty-http                            │ CVE-2023-40167      │          │        │ 9.4.48.v20220622  │ 9.4.52, 10.0.16, 11.0.16, 12.0.1                 │ jetty: Improper validation of HTTP/1 content-length          │
│ (jetty-http-9.4.48.v20220622.jar)                       │                     │          │        │                   │                                                  │ https://avd.aquasec.com/nvd/cve-2023-40167                   │
├─────────────────────────────────────────────────────────┼─────────────────────┤          │        │                   ├──────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ org.eclipse.jetty:jetty-server                          │ CVE-2023-26048      │          │        │                   │ 9.4.51.v20230217, 10.0.14, 11.0.14               │ jetty-server: OutOfMemoryError for large multipart without   │
│ (jetty-server-9.4.48.v20220622.jar)                     │                     │          │        │                   │                                                  │ filename read via request.getParameter()                     │
│                                                         │                     │          │        │                   │                                                  │ https://avd.aquasec.com/nvd/cve-2023-26048                   │
│                                                         ├─────────────────────┼──────────┤        │                   ├──────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                                         │ CVE-2023-26049      │ LOW      │        │                   │ 9.4.51.v20230217, 10.0.14, 11.0.14, 12.0.0.beta0 │ jetty-server: Cookie parsing of quoted values can exfiltrate │
│                                                         │                     │          │        │                   │                                                  │ values from other cookies...                                 │
│                                                         │                     │          │        │                   │                                                  │ https://avd.aquasec.com/nvd/cve-2023-26049                   │
├─────────────────────────────────────────────────────────┼─────────────────────┤          │        │                   ├──────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ org.eclipse.jetty:jetty-servlets                        │ CVE-2023-36479      │          │        │                   │ 9.4.52, 10.0.16, 11.0.16                         │ jetty: Improper addition of quotation marks to user inputs   │
│ (jetty-servlets-9.4.48.v20220622.jar)                   │                     │          │        │                   │                                                  │ in CgiServlet                                                │
│                                                         │                     │          │        │                   │                                                  │ https://avd.aquasec.com/nvd/cve-2023-36479                   │
├─────────────────────────────────────────────────────────┼─────────────────────┼──────────┤        ├───────────────────┼──────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ org.scala-lang:scala-library (scala-library-2.13.8.jar) │ CVE-2022-36944      │ CRITICAL │        │ 2.13.8            │ 2.13.9                                           │ deserialization gadget chain                                 │
│                                                         │                     │          │        │                   │                                                  │ https://avd.aquasec.com/nvd/cve-2022-36944                   │
├─────────────────────────────────────────────────────────┼─────────────────────┼──────────┤        ├───────────────────┼──────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ org.xerial.snappy:snappy-java (snappy-java-1.1.8.4.jar) │ CVE-2023-34455      │ HIGH     │        │ 1.1.8.4           │ 1.1.10.1                                         │ snappy-java: Unchecked chunk length leads to DoS             │
│                                                         │                     │          │        │                   │                                                  │ https://avd.aquasec.com/nvd/cve-2023-34455                   │
│                                                         ├─────────────────────┤          │        │                   ├──────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                                         │ CVE-2023-43642      │          │        │                   │ 1.1.10.4                                         │ snappy-java: Missing upper bound check on chunk length in    │
│                                                         │                     │          │        │                   │                                                  │ snappy-java can lead...                                      │
│                                                         │                     │          │        │                   │                                                  │ https://avd.aquasec.com/nvd/cve-2023-43642                   │
│                                                         ├─────────────────────┼──────────┤        │                   ├──────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                                         │ CVE-2023-34453      │ MEDIUM   │        │                   │ 1.1.10.1                                         │ snappy-java: Integer overflow in shuffle leads to DoS        │
│                                                         │                     │          │        │                   │                                                  │ https://avd.aquasec.com/nvd/cve-2023-34453                   │
│                                                         ├─────────────────────┤          │        │                   │                                                  ├──────────────────────────────────────────────────────────────┤
│                                                         │ CVE-2023-34454      │          │        │                   │                                                  │ snappy-java: Integer overflow in compress leads to DoS       │
│                                                         │                     │          │        │                   │                                                  │ https://avd.aquasec.com/nvd/cve-2023-34454                   │
└─────────────────────────────────────────────────────────┴─────────────────────┴──────────┴────────┴───────────────────┴──────────────────────────────────────────────────┴──────────────────────────────────────────────────────────────┘
```